### PR TITLE
Add serde support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,21 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 
+# For external trait impls
+serde_ = { version = "1.0.114", default-features = false, optional = true, package = "serde" }
+
 [dev-dependencies]
 rand = { version = "0.7.3", features = ["small_rng"] }
 quickcheck = { version = "0.9", default-features = false }
 
+[features]
+serde = [ "serde_" ]
+
 [target.'cfg(not(target_env="msvc"))'.dev-dependencies]
 jemallocator = "0.3"
+
+[package.metadata.docs.rs]
+features = ["serde"]
 
 [[bench]]
 name = "vroom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_ = { version = "1.0.114", default-features = false, optional = true, packa
 rand = { version = "0.7.3", features = ["small_rng"] }
 quickcheck = { version = "0.9", default-features = false }
 serde_test = "1.0.114"
+serde_json = "1.0.56"
 
 [features]
 serde = [ "serde_" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_ = { version = "1.0.114", default-features = false, optional = true, packa
 [dev-dependencies]
 rand = { version = "0.7.3", features = ["small_rng"] }
 quickcheck = { version = "0.9", default-features = false }
+serde_test = "1.0.114"
 
 [features]
 serde = [ "serde_" ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,18 @@ jobs:
           - thumbv7m-none-eabi
      - bash: cargo check --target thumbv7m-none-eabi
        displayName: cargo check --target thumbv7m-none-eabi
+ - job: features
+   displayName: "Check feature combinations"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: stable
+     - script: cargo install cargo-hack
+       displayName: install cargo-hack
+     - script: cargo hack --feature-powerset check
+       displayName: cargo hack
  - job: miri
    displayName: "Run miri on test suite"
    pool:
@@ -33,7 +45,7 @@ jobs:
            - miri
      - script: cargo miri setup
        displayName: cargo miri setup
-     - script: cargo miri test -- -Zmiri-ignore-leaks
+     - script: cargo miri test --features serde -- -Zmiri-ignore-leaks
        displayName: cargo miri test
 
 resources:

--- a/src/external_trait_impls/mod.rs
+++ b/src/external_trait_impls/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "serde")]
+mod serde;

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -81,6 +81,46 @@ where
         };
         deserializer.deserialize_seq(visitor)
     }
+
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VcInPlaceVisitor<'a, T>(&'a mut Vc<T>);
+        impl<'a, 'de, T> Visitor<'de> for VcInPlaceVisitor<'a, T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = ();
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a sequence")
+            }
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let hint = helper::cautious_size_hint(seq.size_hint());
+                if let Some(additional) = hint.checked_sub(self.0.len()) {
+                    self.0.reserve(additional);
+                }
+                for i in 0..self.0.len() {
+                    let next = {
+                        let next_place = helper::InPlaceSeed(&mut self.0[i]);
+                        seq.next_element_seed(next_place)?
+                    };
+                    if next.is_none() {
+                        self.0.truncate(i);
+                        return Ok(());
+                    }
+                }
+                while let Some(value) = seq.next_element()? {
+                    self.0.push(value);
+                }
+                Ok(())
+            }
+        }
+        deserializer.deserialize_seq(VcInPlaceVisitor(place))
+    }
 }
 
 #[cfg(test)]

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -198,7 +198,7 @@ mod tests {
         atoner.push(3);
         atoner.push(4);
         let json = serde_json::to_string(&atoner).unwrap();
-        let baptized: Vc<u32> = serde_json::from_str(&json).unwrap();
+        let baptized: alloc::vec::Vec<u32> = serde_json::from_str(&json).unwrap();
         for (a, b) in atoner.iter().zip(baptized.iter()) {
             assert!(
                 a == b,

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -1,0 +1,61 @@
+use core::fmt;
+use core::marker::PhantomData;
+
+use serde_::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+use serde_::ser::{Serialize, Serializer};
+
+use crate::Vc;
+
+impl<T> Serialize for Vc<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(self)
+    }
+}
+
+#[inline]
+fn cautious_size_hint(hint: Option<usize>) -> usize {
+    core::cmp::min(hint.unwrap_or(0), 4096)
+}
+
+impl<'de, T> Deserialize<'de> for Vc<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VcVisitor<T> {
+            marker: PhantomData<T>,
+        }
+        impl<'de, T> Visitor<'de> for VcVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = Vc<T>;
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a sequence")
+            }
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut values = Vc::with_capacity(cautious_size_hint(seq.size_hint()));
+                while let Some(value) = seq.next_element()? {
+                    values.push(value);
+                }
+                Ok(values)
+            }
+        }
+        let visitor = VcVisitor {
+            marker: PhantomData,
+        };
+        deserializer.deserialize_seq(visitor)
+    }
+}

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -18,6 +18,7 @@ where
     }
 }
 
+/// Picked from https://github.com/serde-rs/serde/blob/9f331cc25753edd71ad7ab0ea08a430fefaa90e1/serde/src/private/de.rs#L203
 #[inline]
 fn cautious_size_hint(hint: Option<usize>) -> usize {
     core::cmp::min(hint.unwrap_or(0), 4096)

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -136,4 +136,34 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn test_vec_to_vc_serde() {
+        let sinful: alloc::vec::Vec<u32> = vec![1, 2, 3, 4];
+        let json = serde_json::to_string(&sinful).unwrap();
+        let atoner: Vc<u32> = serde_json::from_str(&json).unwrap();
+        for (s, a) in sinful.iter().zip(atoner.iter()) {
+            assert!(
+                s == a,
+                "Deserialized Vc is not identical to the original Vec."
+            );
+        }
+    }
+
+    #[test]
+    fn test_vc_to_vec_serde() {
+        let mut atoner: Vc<u32> = Vc::new();
+        atoner.push(1);
+        atoner.push(2);
+        atoner.push(3);
+        atoner.push(4);
+        let json = serde_json::to_string(&atoner).unwrap();
+        let baptized: Vc<u32> = serde_json::from_str(&json).unwrap();
+        for (a, b) in atoner.iter().zip(baptized.iter()) {
+            assert!(
+                a == b,
+                "Deserialized Vec is not identical to the original Vc."
+            );
+        }
+    }
 }

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -96,7 +96,7 @@ mod tests {
         for i in 1..=8 {
             my_vec.push(i);
         }
-        assert!(my_vec.is_split());
+        assert!(my_vec.is_atoning());
         assert_tokens(
             &my_vec,
             &[

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -59,3 +59,58 @@ where
         deserializer.deserialize_seq(visitor)
     }
 }
+
+#[cfg(test)]
+#[cfg(not(tarpaulin_include))] // don't count for coverage
+mod tests {
+    use crate::Vc;
+    use serde_test::{assert_tokens, Token};
+
+    #[test]
+    fn test_serde_empty_vc() {
+        let my_vec: Vc<u32> = Vc::default();
+        assert_tokens(&my_vec, &[Token::Seq { len: Some(0) }, Token::SeqEnd])
+    }
+
+    #[test]
+    fn test_serde_non_empty() {
+        let mut my_vec: Vc<u32> = Vc::default();
+        my_vec.push(1);
+        my_vec.push(2);
+        my_vec.push(3);
+        assert_tokens(
+            &my_vec,
+            &[
+                Token::Seq { len: Some(3) },
+                Token::U32(1),
+                Token::U32(2),
+                Token::U32(3),
+                Token::SeqEnd,
+            ],
+        )
+    }
+
+    #[test]
+    fn test_serde_while_atoning() {
+        let mut my_vec: Vc<u32> = Vc::new();
+        for i in 1..=8 {
+            my_vec.push(i);
+        }
+        assert!(my_vec.is_split());
+        assert_tokens(
+            &my_vec,
+            &[
+                Token::Seq { len: Some(8) },
+                Token::U32(1),
+                Token::U32(2),
+                Token::U32(3),
+                Token::U32(4),
+                Token::U32(5),
+                Token::U32(6),
+                Token::U32(7),
+                Token::U32(8),
+                Token::SeqEnd,
+            ],
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ use core::ops::{Index, IndexMut, RangeBounds};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 
+mod external_trait_impls;
 mod iter;
 
 /// A `VecDeque` (and `Vec`) variant that spreads resize load across pushes.

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,2 +1,2 @@
 [main]
-features = ""
+features = "serde"


### PR DESCRIPTION
Partially resolve #1 

It was fun adding this feature.

I don't know if the `test_serde_while_atoning` is needed or not, but I added it just in case. Note that this will conflict with the name change in #2.

I am still not sure about the config stuff (Cargo.toml, tarpaulin.toml, and azure-pipelines.yml). Please check!