### PR TITLE
Switch to quickcheck 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "jemallocator",
  "lazy_static",
  "quickcheck",
- "rand",
+ "rand 0.7.3",
  "rayon",
  "serde",
  "serde_json",
@@ -97,7 +97,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -175,12 +186,11 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "quickcheck"
-version = "0.9.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "rand",
- "rand_core",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -189,12 +199,21 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_hc",
  "rand_pcg",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -204,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -213,7 +232,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -222,7 +250,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -231,7 +259,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -299,3 +327,9 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_ = { version = "1.0.114", default-features = false, optional = true, packa
 [dev-dependencies]
 lazy_static = "1.2"
 rand = { version = "0.7.3", features = ["small_rng"] }
-quickcheck = { version = "0.9", default-features = false }
+quickcheck = { version = "1.0", default-features = false }
 rayon_ = { version = "1.2.0", package = "rayon" }
 serde_test = "1.0.114"
 serde_json = "1.0.56"

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -106,15 +106,15 @@ impl<T> Arbitrary for Op<T>
 where
     T: Arbitrary,
 {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        match g.gen::<u32>() % 9 {
+    fn arbitrary(g: &mut Gen) -> Self {
+        match u32::arbitrary(g) % 9 {
             0 | 1 => Push(T::arbitrary(g)),
             2 => Pop,
             3 => PopFront,
-            4 => SwapRemove(g.gen::<u16>()),
-            5 => Insert(g.gen::<u16>(), T::arbitrary(g)),
-            6 => Truncate(g.gen::<u8>()),
-            7 => Reserve(g.gen::<u8>()),
+            4 => SwapRemove(u16::arbitrary(g)),
+            5 => Insert(u16::arbitrary(g), T::arbitrary(g)),
+            6 => Truncate(u8::arbitrary(g)),
+            7 => Reserve(u8::arbitrary(g)),
             8 => CheckEnds,
             _ => unreachable!(),
         }
@@ -221,12 +221,12 @@ impl Deref for Alpha {
 const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
 
 impl Arbitrary for Alpha {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let len = g.next_u32() % g.size() as u32;
+    fn arbitrary(g: &mut Gen) -> Self {
+        let len = u32::arbitrary(g) % g.size() as u32;
         let len = min(len, 16);
         Alpha(
             (0..len)
-                .map(|_| ALPHABET[g.next_u32() as usize % ALPHABET.len()] as char)
+                .map(|_| ALPHABET[u32::arbitrary(g) as usize % ALPHABET.len()] as char)
                 .collect(),
         )
     }
@@ -251,8 +251,8 @@ impl<T> Arbitrary for Large<Vec<T>>
 where
     T: Arbitrary,
 {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let len = g.next_u32() % (g.size() * 10) as u32;
+    fn arbitrary(g: &mut Gen) -> Self {
+        let len = u32::arbitrary(g) % (g.size() * 10) as u32;
         Large((0..len).map(|_| T::arbitrary(g)).collect())
     }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -82,7 +82,8 @@ quickcheck! {
         elements.iter().all(|v| vs.contains(v)) && vs.iter().all(|v| elements.contains(&v))
     }
 
-    fn with_cap(cap: usize) -> bool {
+    fn with_cap(cap: u8) -> bool {
+        let cap = cap as usize;
         let vs: Vc<u8> = Vc::with_capacity(cap);
         println!("wish: {}, got: {} (diff: {})", cap, vs.capacity(), vs.capacity() as isize - cap as isize);
         vs.capacity() >= cap


### PR DESCRIPTION
As far as I understand the only breaking change was published in [this commit](https://github.com/BurntSushi/quickcheck/commit/d286e4db208535692dd5fb6a580077e5ecbb747b). 

I found two significant differences:
1. signature for `Arbitrary::arbitrary` changed
2. it's no longer possible to call `RngCore::next_u32`

I changed every call to `RngCore::next_u32` to `u32::arbitrary`. It was based purely on intuition, and seems to be wrong. The tests build, but don't pass &mdash; somewhere it tries to allocate more memory than max of `u32`. As I am writing this I'm not sure how to solve this. I would have to get more insight into how `quickcheck` works and why the tests are implemented the way they are.  

