### PR TITLE
some cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,7 +112,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.59"] # deque_range
+        msrv: ["1.73"] # uXX::div_ceil
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,7 +112,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.73"] # uXX::div_ceil
+        msrv: ["1.73"]
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.7"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+rust-version = "1.73" # uXX::div_ceil
 
 readme = "README.md"
 description = "A VecDeque and Vec variant that spreads resize load across pushes."

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,8 +13,8 @@ fn size_hint(
         let (lo2, hi2) = tail;
 
         // all vec_deque iterators are ExactSizeIterator
-        let hi1 = hi1.unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
-        let hi2 = hi2.unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
+        let hi1 = unsafe { hi1.unwrap_unchecked() };
+        let hi2 = unsafe { hi2.unwrap_unchecked() };
 
         (lo1 + lo2, Some(hi1 + hi2))
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2030,7 +2030,6 @@ mod tests {
     use super::Vc;
     use std::cell::RefCell;
     use std::collections::VecDeque;
-    use std::usize;
     use std::vec::Vec;
 
     #[test]
@@ -2169,7 +2168,7 @@ mod tests {
         assert!(m2.iter().copied().eq(1..=8));
     }
 
-    thread_local! { static DROP_VECTOR: RefCell<Vec<i32>> = RefCell::new(Vec::new()) }
+    thread_local! { static DROP_VECTOR: RefCell<Vec<i32>> = const {RefCell::new(Vec::new())} }
 
     #[derive(Hash, PartialEq, Eq)]
     struct Droppable {
@@ -2449,8 +2448,8 @@ mod tests {
         vs.push(1);
         vs.push(2);
 
-        assert_eq!(format!("{:?}", vs), "[1, 2]");
-        assert_eq!(format!("{:?}", empty), "[]");
+        assert_eq!(format!("{vs:?}"), "[1, 2]");
+        assert_eq!(format!("{empty:?}"), "[]");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,8 @@
 #![warn(rustdoc::all)]
 
 #[cfg(test)]
-#[macro_use]
 extern crate std;
 
-#[cfg_attr(test, macro_use)]
 extern crate alloc;
 
 use core::cmp::Ordering;
@@ -2031,6 +2029,7 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::vec::Vec;
+    use std::{format, thread_local, vec};
 
     #[test]
     fn zero_capacities() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,7 +548,7 @@ impl<T, const R: usize> CustomVc<T, R> {
     /// buf.shrink_to(0);
     /// assert!(buf.capacity() >= 4);
     /// ```
-    fn shrink_to(&mut self, min_capacity: usize) {
+    pub fn shrink_to(&mut self, min_capacity: usize) {
         // Calculate the minimal number of elements that we need to reserve
         // space for.
         let mut need = self.new_tail.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2536,7 +2536,7 @@ mod tests {
         }
         assert!(vs.is_atoning());
 
-        vs[9];
+        let _ = vs[9];
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2033,13 +2033,13 @@ mod tests {
     use std::vec::Vec;
 
     #[test]
-    fn test_zero_capacities() {
+    fn zero_capacities() {
         assert_eq!(VecDeque::<i32>::with_capacity(0).capacity(), 0);
         assert_eq!(Vc::<i32>::with_capacity(0).capacity(), 0);
     }
 
     #[test]
-    fn test_create_capacity_zero() {
+    fn create_capacity_zero() {
         let mut m = Vc::with_capacity(0);
 
         m.push(1);
@@ -2053,7 +2053,7 @@ mod tests {
     }
 
     #[test]
-    fn test_push() {
+    fn push() {
         let mut m = Vc::new();
         assert_eq!(m.len(), 0);
         m.push(1);
@@ -2065,7 +2065,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_push() {
+    fn split_push() {
         // the code below assumes that R is 4
         assert_eq!(Vc::<i32>::move_amount(), 4);
 
@@ -2144,7 +2144,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clone() {
+    fn clone() {
         let mut m = Vc::new();
         for i in 1..=8 {
             assert_eq!(m.len(), i - 1);
@@ -2156,7 +2156,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_from() {
+    fn clone_from() {
         let mut m = Vc::new();
         let mut m2 = Vc::new();
         for i in 1..=8 {
@@ -2200,7 +2200,7 @@ mod tests {
     }
 
     #[test]
-    fn test_drops() {
+    fn drops() {
         DROP_VECTOR.with(|slot| {
             *slot.borrow_mut() = vec![0; 100];
         });
@@ -2254,7 +2254,7 @@ mod tests {
     }
 
     #[test]
-    fn test_into_iter_drops() {
+    fn into_iter_drops() {
         DROP_VECTOR.with(|v| {
             *v.borrow_mut() = vec![0; 100];
         });
@@ -2312,13 +2312,13 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_empty_remove() {
+    fn empty_remove() {
         let mut vs: Vc<i32> = Vc::new();
         vs.remove(0);
     }
 
     #[test]
-    fn test_empty_iter() {
+    fn empty_iter() {
         let mut vs: Vc<i32> = Vc::new();
         assert_eq!(vs.drain(..).next(), None);
         assert_eq!(vs.iter().next(), None);
@@ -2330,13 +2330,13 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_empty_swap_remove() {
+    fn empty_swap_remove() {
         let mut vs: Vc<i32> = Vc::new();
         vs.swap_remove(0);
     }
 
     #[test]
-    fn test_lots_of_pushes() {
+    fn lots_of_pushes() {
         let mut vs = Vc::new();
 
         #[cfg(not(any(tarpaulin, miri)))]
@@ -2401,7 +2401,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_empty() {
+    fn is_empty() {
         let mut vs = Vc::with_capacity(4);
         vs.push(1);
         assert!(!vs.is_empty());
@@ -2410,7 +2410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iterate() {
+    fn iterate() {
         let mut vs = Vc::with_capacity(4);
         for i in 0..=36 {
             vs.push(i * 2);
@@ -2422,7 +2422,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eq() {
+    fn eq() {
         let mut vs1 = Vc::new();
         for v in (1..).take(8) {
             vs1.push(v);
@@ -2441,7 +2441,7 @@ mod tests {
     }
 
     #[test]
-    fn test_show() {
+    fn show() {
         let mut vs = Vc::new();
         let empty: Vc<i32> = Vc::new();
 
@@ -2453,7 +2453,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_iter() {
+    fn from_iter() {
         let xs = 0..8;
 
         let vs: Vc<_> = xs.clone().collect();
@@ -2461,7 +2461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_size_hint() {
+    fn size_hint() {
         let xs = 0..8;
 
         let vs: Vc<_> = xs.clone().collect();
@@ -2474,7 +2474,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_len() {
+    fn iter_len() {
         let xs = 0..8;
 
         let vs: Vc<_> = xs.clone().collect();
@@ -2487,7 +2487,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_size_hint() {
+    fn mut_size_hint() {
         let xs = 0..8;
 
         let mut vs: Vc<_> = xs.clone().collect();
@@ -2500,7 +2500,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mut_len() {
+    fn iter_mut_len() {
         let xs = 0..8;
 
         let mut vs: Vc<_> = xs.clone().collect();
@@ -2513,7 +2513,7 @@ mod tests {
     }
 
     #[test]
-    fn test_index() {
+    fn index() {
         let mut vs = Vc::with_capacity(7);
 
         for i in 1..=8 {
@@ -2526,7 +2526,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_index_nonexistent() {
+    fn index_nonexistent() {
         let mut vs = Vc::new();
 
         for i in 1..=8 {
@@ -2538,7 +2538,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extend_ref() {
+    fn extend_ref() {
         let mut a = Vc::new();
         a.push("one");
         let mut b = Vc::new();
@@ -2554,7 +2554,7 @@ mod tests {
     }
 
     #[test]
-    fn test_capacity_not_less_than_len() {
+    fn capacity_not_less_than_len() {
         let mut a = Vc::new();
         let mut item = 0;
 
@@ -2579,7 +2579,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retain() {
+    fn retain() {
         let mut vs: Vc<i32> = Vc::new();
         for x in 0..130 {
             vs.push(x);
@@ -2594,7 +2594,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type_inference() {
+    fn type_inference() {
         // Simply makes sure that `Vc::default` can compile
 
         let mut vc_default = Vc::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,9 +543,9 @@ impl<T, const R: usize> CustomVc<T, R> {
     /// let mut buf = Vc::with_capacity(15);
     /// buf.extend(0..4);
     /// assert_eq!(buf.capacity(), 15);
-    /// // buf.shrink_to(6);
+    /// buf.shrink_to(6);
     /// assert!(buf.capacity() >= 6);
-    /// // buf.shrink_to(0);
+    /// buf.shrink_to(0);
     /// assert!(buf.capacity() >= 4);
     /// ```
     fn shrink_to(&mut self, min_capacity: usize) {
@@ -565,12 +565,9 @@ impl<T, const R: usize> CustomVc<T, R> {
         } else if min_capacity <= need {
             self.new_tail.shrink_to_fit();
         }
-        let _min_size = usize::max(need, min_capacity);
+        let min_size = usize::max(need, min_capacity);
 
-        // FIXME: for now, this is a no-op
-        // TODO: use VecDeque::shrink_to once available
-        //       then, uncomment relevant code in doctest
-        // self.new_tail.shrink_to(min_size);
+        self.new_tail.shrink_to(min_size);
     }
 
     /// Shortens the `Vc`, keeping the first `len` elements and dropping

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,7 @@ impl<T, const R: usize> CustomVc<T, R> {
             // We move R items on each insert.
             // That means we need to accomodate another
             // lo.table.len() / R (rounded up) inserts to move them all.
-            need += (old_len + R - 1) / R;
+            need += old_len.div_ceil(R);
         } else if min_capacity <= need {
             self.new_tail.shrink_to_fit();
         }
@@ -985,7 +985,7 @@ impl<T, const R: usize> CustomVc<T, R> {
     where
         T: PartialEq<T>,
     {
-        self.new_tail.contains(x) || self.old_head.as_ref().map_or(false, |v| v.contains(x))
+        self.new_tail.contains(x) || self.old_head.as_ref().is_some_and(|v| v.contains(x))
     }
 
     /// Provides a reference to the front element, or `None` if the `Vc` is
@@ -1599,8 +1599,7 @@ impl<T, const R: usize> CustomVc<T, R> {
         let need = self.new_tail.len();
         //  - We move R items on each push, so to move len items takes
         //    len / R pushes (rounded up!)
-        //  - Since we want to round up, we pull the old +R-1 trick
-        let pushes = (self.new_tail.len() + R - 1) / R;
+        let pushes = self.new_tail.len().div_ceil(R);
         //  - That's len + len/R
         //    Which is == R*len/R + len/R
         //    Which is == ((R+1)*len)/R
@@ -1935,7 +1934,7 @@ impl<A, const R: usize> Extend<A> for CustomVc<A, R> {
         let reserve = if self.is_empty() {
             iter.size_hint().0
         } else {
-            (iter.size_hint().0 + 1) / 2
+            iter.size_hint().0.div_ceil(2)
         };
         self.reserve(reserve);
         iter.for_each(move |v| {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -83,8 +83,9 @@ quickcheck! {
     fn with_cap(cap: u8) -> bool {
         let cap = cap as usize;
         let vs: Vc<u8> = Vc::with_capacity(cap);
-        println!("wish: {}, got: {} (diff: {})", cap, vs.capacity(), vs.capacity() as isize - cap as isize);
-        vs.capacity() >= cap
+        let vs_cap = vs.capacity();
+        println!("wish: {}, got: {} (diff: {})", cap, vs_cap, vs_cap as isize - cap as isize);
+        vs_cap >= cap
     }
 }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -8,8 +8,6 @@ use atone::Vc;
 use quickcheck::Arbitrary;
 use quickcheck::Gen;
 
-use rand::Rng;
-
 use std::cmp::min;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -17,10 +15,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
 
-fn set<'a, T: 'a, I>(iter: I) -> HashSet<T>
+fn set<'a, T, I>(iter: I) -> HashSet<T>
 where
     I: IntoIterator<Item = &'a T>,
-    T: Copy + Hash + Eq,
+    T: Copy + Hash + Eq + 'a,
 {
     iter.into_iter().cloned().collect()
 }
@@ -67,7 +65,7 @@ quickcheck! {
             }
         }
         let elements = &set(&push) - &set(&remove);
-        elements.iter().all(|v| vs.contains(v)) && vs.iter().all(|v| elements.contains(&v))
+        elements.iter().all(|v| vs.contains(v)) && vs.iter().all(|v| elements.contains(v))
     }
 
     fn push_retain(push: Vec<u8>, retain: Vec<u8>) -> bool {
@@ -78,7 +76,7 @@ quickcheck! {
         vs.retain(|v| retain.contains(v));
         let push = set(&push);
         let retain = set(&retain);
-        let elements: Vec<_> = push.intersection(&retain).into_iter().collect();
+        let elements: Vec<_> = push.intersection(&retain).collect();
         elements.iter().all(|v| vs.contains(v)) && vs.iter().all(|v| elements.contains(&v))
     }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1,7 +1,6 @@
 #![cfg(not(miri))]
 
-#[macro_use]
-extern crate quickcheck;
+use quickcheck::quickcheck;
 
 use atone::Vc;
 

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "rayon")]
 
-#[macro_use]
-extern crate lazy_static;
+use lazy_static::lazy_static;
 
 use atone::Vc;
 use rayon_::iter::{


### PR DESCRIPTION
this PR deals with:
- Clippy lints
- old idioms
- a now-resolvable-thanks-to-new-but-not-really-that-new-Rust-version TODO
- and a bunch of other smaller things

Some of the introduced methods (like `is_some_and`) would theoretically push MSRV up quite a bit, but the crate doesn't even define one so I think this should be ok.